### PR TITLE
Serilog 2, Custom Groups, and Event Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,87 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/bol0v48ujapxobym/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-raygun/branch/master)
 
 A Serilog sink that writes events to Raygun
+
+## Usage
+
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Verbose()
+    .WriteTo.Raygun("RaygunAPIKey",
+      ListOfWrapperExceptions,
+      "CustomUserNameProperty",
+      "CustomAppVersionProperty",
+      LogEventLevel.Information,
+      CustomFormatProvider,
+      new[] { "globalTag1", "globalTag2" },
+      new[] { "ignoreField1", "ignoreField2" },
+      "CustomGroupKeyProperty",
+      "CustomTagsProperty")
+    .CreateLogger();
+```
+### Required
+#### applicationKey
+`string`
+
+### Optional
+#### wrapperExceptions
+`type: IEnumerable<Exception>`
+
+`default: null`
+
+#### userNameProperty
+`type: string`
+
+`default: UserName`
+
+```csharp
+Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random error"), "other information");
+```
+
+#### applicationVersionProperty
+`type: string`
+
+`default: ApplicationVersion`
+
+```csharp
+Log.ForContext("CustomAppVersionProperty", "1.2.11").Error(new Exception("random error"), "other information");
+```
+
+#### restrictedToMinimumLevel
+`type: LogEventLevel`
+
+`default: LogEventLevel.Error`
+
+#### formatProvider
+`type: IFormatProvider`
+
+`default: null`
+
+#### tags
+`type: IEnumerable<string>`
+
+`default: null`
+
+#### ignoredFormFieldNames
+`type: IEnumerable<string>`
+
+`default: null`
+
+#### groupKeyProperty
+`type: string`
+
+`default: GroupKey`
+
+```csharp
+Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Exception("random error"), "other information");
+```
+
+#### tagsProperty
+`type: string`
+
+`default: Tags`
+
+```csharp
+Log.ForContext("CustomTagsProperty", new[] {"tag1", "tag2"}).Error(new Exception("random error"), "other information");
+Log.Error(new Exception("random error"), "other information {@CustomTagsProperty}", new[] {"tag3", "tag4"});
+```

--- a/serilog-sinks-raygun.sln
+++ b/serilog-sinks-raygun.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun", "src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj", "{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}"
 EndProject

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -38,16 +38,20 @@ namespace Serilog
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="tags">Specifies the tags to include with every log message. The log level will always be included as a tag.</param>
         /// <param name="ignoredFormFieldNames">Specifies the form field names which to ignore when including request form data.</param>
+        /// <param name="groupKeyProperty">The property containing the custom group key for the Raygun message.</param>
+        /// <param name="tagsProperty">The property where additional tags are stored when emitting log events</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Raygun(
             this LoggerSinkConfiguration loggerConfiguration,
-             string applicationKey,  
+            string applicationKey,
             IEnumerable<Type> wrapperExceptions = null, string userNameProperty = "UserName", string applicationVersionProperty = "ApplicationVersion",
             LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error,
             IFormatProvider formatProvider = null,
             IEnumerable<string> tags = null,
-            IEnumerable<string> ignoredFormFieldNames = null)
+            IEnumerable<string> ignoredFormFieldNames = null,
+            string groupKeyProperty = "GroupKey",
+            string tagsProperty = "Tags")
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
@@ -55,9 +59,8 @@ namespace Serilog
                 throw new ArgumentNullException("applicationKey");
 
             return loggerConfiguration.Sink(
-                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames),
+                new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty),
                 restrictedToMinimumLevel);
         }
-
     }
 }

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog</RootNamespace>
     <AssemblyName>Serilog.Sinks.Raygun</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,21 +43,14 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mindscape.Raygun4Net, Version=5.0.1.0, Culture=neutral, PublicKeyToken=20dddfb3684a7aa5, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Mindscape.Raygun4Net.Signed.5.0.1\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
+    <Reference Include="Mindscape.Raygun4Net, Version=5.4.1.0, Culture=neutral, PublicKeyToken=20dddfb3684a7aa5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mindscape.Raygun4Net.Signed.5.4.1\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
     </Reference>
-    <Reference Include="Mindscape.Raygun4Net4, Version=5.0.1.0, Culture=neutral, PublicKeyToken=002e1b57394fa9b9, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Mindscape.Raygun4Net.Signed.5.0.1\lib\net40\Mindscape.Raygun4Net4.dll</HintPath>
+    <Reference Include="Mindscape.Raygun4Net4, Version=5.4.1.0, Culture=neutral, PublicKeyToken=002e1b57394fa9b9, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mindscape.Raygun4Net.Signed.5.4.1\lib\net40\Mindscape.Raygun4Net4.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.5.1\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.5.1\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.3.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.nuspec
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.nuspec
@@ -1,18 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
-    <id>Serilog.Sinks.Raygun</id>
-    <version>$version$</version>
-    <authors>Michiel van Oudheusden</authors>
-    <description>Serilog event sink that writes to the Raygun.io service.</description>
-    <language>en-US</language>
-    <projectUrl>http://serilog.net</projectUrl>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
-    <tags>serilog logging Raygun.io error</tags>
-    <dependencies>
-      <dependency id="Serilog" version="1.5" />
-      <dependency id="Mindscape.Raygun4Net.Signed" version="2.0.4" />
-    </dependencies>
-  </metadata>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+    <metadata>
+        <id>Serilog.Sinks.Raygun</id>
+        <version>$version$</version>
+        <authors>Michiel van Oudheusden</authors>
+        <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+        <projectUrl>http://serilog.net</projectUrl>
+        <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Serilog event sink that writes to the Raygun.io service.</description>
+        <language>en-US</language>
+        <tags>serilog logging Raygun.io error</tags>
+        <dependencies>
+            <group targetFramework=".NETFramework4.6">
+                <dependency id="Serilog" version="2.3.0" />
+                <dependency id="Mindscape.Raygun4Net.Signed" version="5.4.1" />
+            </group>
+        </dependencies>
+    </metadata>
 </package>

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunPropertyFormatter.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunPropertyFormatter.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.Raygun
             typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
                 typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal),
             typeof(byte[])
-        }; 
+        };
 
         /// <summary>
         /// Simplify the object so as to make handling the serialized
@@ -83,7 +83,7 @@ namespace Serilog.Sinks.Raygun
 
             return null;
         }
-        
+
         static object SimplifyScalar(object value)
         {
             if (value == null) return null;

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -30,14 +30,14 @@ namespace Serilog.Sinks.Raygun
     /// </summary>
     public class RaygunSink : ILogEventSink
     {
-        private readonly IFormatProvider _formatProvider;
-        private readonly string _userNameProperty;
-        private readonly string _applicationVersionProperty;
-        private readonly IEnumerable<string> _tags;
-        private readonly IEnumerable<string> _ignoredFormFieldNames;
-        private readonly string _groupKeyProperty;
-        private readonly string _tagsProperty;
-        private readonly RaygunClient _client;
+        readonly IFormatProvider _formatProvider;
+        readonly string _userNameProperty;
+        readonly string _applicationVersionProperty;
+        readonly IEnumerable<string> _tags;
+        readonly IEnumerable<string> _ignoredFormFieldNames;
+        readonly string _groupKeyProperty;
+        readonly string _tagsProperty;
+        readonly RaygunClient _client;
 
         /// <summary>
         /// Construct a sink that saves errors to the Raygun.io service. Properties are being send as userdata and the level is included as tag. The message is included inside the userdata.

--- a/src/Serilog.Sinks.Raygun/packages.config
+++ b/src/Serilog.Sinks.Raygun/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mindscape.Raygun4Net.Signed" version="5.0.1" targetFramework="net45" />
-  <package id="Serilog" version="1.5.1" targetFramework="net45" />
+  <package id="Mindscape.Raygun4Net.Signed" version="5.4.1" targetFramework="net46" />
+  <package id="Serilog" version="2.3.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
* move to latest Serilog v2 package and latest Raygun v5 package
* changed target framework to .net 4.6
* added support for Raygun custom group key
* updated nuspec dependencies
* minor update to comments
* added new tags property name parameter which allows tags to be passed per event, in addition to the global tags set on init
* added usage information to readme