### PR TITLE
Fixes #7 - Redundant quotation marks included in the version string

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -117,7 +117,7 @@ namespace Serilog.Sinks.Raygun
                 logEvent.Properties.ContainsKey(_applicationVersionProperty) &&
                 logEvent.Properties[_applicationVersionProperty] != null)
             {
-                raygunMessage.Details.Version = logEvent.Properties[_applicationVersionProperty].ToString();
+                raygunMessage.Details.Version = logEvent.Properties[_applicationVersionProperty].ToString("l", null);
             }
 
             // Build up the rest of the message


### PR DESCRIPTION
Implemented the change that was recommended in [this comment](https://github.com/serilog/serilog-sinks-raygun/issues/7#issuecomment-255022859).