### PR TITLE
Adding .NET 4.6 target framework

### DIFF
--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;net461</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Michiel van Oudheusden</Authors>
     <Company>Serilog</Company>
@@ -20,6 +20,10 @@
     <FileVersion>3.0.0.0</FileVersion>
   </PropertyGroup>
   
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="Mindscape.Raygun4Net" Version="5.5.2" />
+  </ItemGroup>
+    
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Mindscape.Raygun4Net" Version="5.5.2" />
   </ItemGroup>


### PR DESCRIPTION
Adding a target to .NET 4.6.  Hoping to add more compatibility to the sink so I don't have to upgrade all the libraries on a project I am working on to .NET 4.6 right now and maybe help some other people out as well by doing that. 