### PR TITLE
Use MessageTemplate in lieu of Exception.Message when logging a non-exception message

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -100,9 +100,15 @@ namespace Serilog.Sinks.Raygun
                 OccurredOn = logEvent.Timestamp.UtcDateTime
             };
 
-            // Add exception when available
-            if (logEvent.Exception != null)
-                raygunMessage.Details.Error = RaygunErrorMessageBuilder.Build(logEvent.Exception);
+            // Add exception when available, else use the message template so events can be grouped
+            raygunMessage.Details.Error = logEvent.Exception != null
+                ? RaygunErrorMessageBuilder.Build(logEvent.Exception)
+                : new RaygunErrorMessage()
+                {
+                    ClassName = logEvent.MessageTemplate.Text,
+                    Message = logEvent.ToString(),
+                    Data = logEvent.Properties.ToDictionary(k => k.Key, v => v.Value.ToString())
+                };
 
             // Add user when requested
             if (!string.IsNullOrWhiteSpace(_userNameProperty) &&

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -106,7 +106,8 @@ namespace Serilog.Sinks.Raygun
                 : new RaygunErrorMessage()
                 {
                     ClassName = logEvent.MessageTemplate.Text,
-                    Message = logEvent.ToString(),
+                    Message = logEvent.MessageTemplate.Text,
+                    
                     Data = logEvent.Properties.ToDictionary(k => k.Key, v => v.Value.ToString())
                 };
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -106,8 +106,7 @@ namespace Serilog.Sinks.Raygun
                 : new RaygunErrorMessage()
                 {
                     ClassName = logEvent.MessageTemplate.Text,
-                    Message = logEvent.MessageTemplate.Text,
-                    
+                    Message = logEvent.MessageTemplate.Text,     
                     Data = logEvent.Properties.ToDictionary(k => k.Key, v => v.Value.ToString())
                 };
 


### PR DESCRIPTION
Currently any logs events  that don't contain an exception, all get grouped in to the same unknown error group.

This pull request, puts the Serilog MessageTemplate into the RayGun exception message slot.