### PR TITLE
Raygun client v6

### DIFF
--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -7,7 +7,7 @@
     <Company>Serilog</Company>
     <Product>Serilog.Sinks.Raygun</Product>
     <Description>Send log events to custom topics in Azure Event Grid</Description>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
+++ b/src/Serilog.Sinks.Raygun/Serilog.Sinks.Raygun.csproj
@@ -13,23 +13,23 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-raygun</RepositoryUrl>
     <PackageTags>serilog sink raygun</PackageTags>
-    <Copyright>Copyright © Serilog Contributors 2017</Copyright>
+    <Copyright>Copyright © Serilog Contributors 2017-2019</Copyright>
 	<Description>Serilog event sink that writes to the Raygun.io service.</Description>
-    <VersionPrefix>3.0.1</VersionPrefix>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Mindscape.Raygun4Net" Version="5.5.2" />
   </ItemGroup>
-    
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="Mindscape.Raygun4Net" Version="5.5.2" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="mindscape.Raygun4Net.AspNetCore" Version="5.5.0" />
+    <PackageReference Include="mindscape.Raygun4Net.AspNetCore" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>	

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using Mindscape.Raygun4Net;
+#if NETSTANDARD2_0
+using Mindscape.Raygun4Net.AspNetCore;
+#else
 using Mindscape.Raygun4Net.Builders;
 using Mindscape.Raygun4Net.Messages;
+#endif
 using Serilog.Core;
 using Serilog.Events;
 


### PR DESCRIPTION
This PR updates the **RaygunClient** client to 6.0 when targeting .NET Standard 2.0.

There's no functional change, only **RaygunClient**'s namespaces have been changed.

Because I consider this a breaking change, I also bumped the version to 4.0.

This fixes #15.