### PR TITLE
Rather format the message than simply display the messageTemplate.Text

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -107,8 +107,8 @@ namespace Serilog.Sinks.Raygun
                 ? RaygunErrorMessageBuilder.Build(logEvent.Exception)
                 : new RaygunErrorMessage()
                 {
-                    ClassName = logEvent.MessageTemplate.Text,
-                    Message = logEvent.MessageTemplate.Text,     
+                    ClassName = logEvent.RenderMessage(_formatProvider),
+                    Message = logEvent.RenderMessage(_formatProvider),     
                     Data = logEvent.Properties.ToDictionary(k => k.Key, v => v.Value.ToString())
                 };
 


### PR DESCRIPTION
If we use the messageTemplate.Text, the placeholders are not replaced.
So the message on Raygun would look like HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms 
vs
 "HTTP "POST" "/home/calculations" responded 500 in 3413.3153 ms