### PR TITLE
Added RaygunClientMessage

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Mindscape.Raygun4Net;
 #if NETSTANDARD2_0
 using Mindscape.Raygun4Net.AspNetCore;
@@ -133,6 +134,13 @@ namespace Serilog.Sinks.Raygun
             raygunMessage.Details.Tags = tags;
             raygunMessage.Details.UserCustomData = properties;
             raygunMessage.Details.MachineName = Environment.MachineName;
+            
+            raygunMessage.Details.Client = new RaygunClientMessage()
+            {
+                Name = "RaygunSerilogSink",
+                Version = new AssemblyName(this.GetType().Assembly.FullName).Version.ToString(),
+                ClientUrl = "https://github.com/serilog/serilog-sinks-raygun"
+            };
 
             // Add the custom group key when provided
             if (properties.TryGetValue(_groupKeyProperty, out var customKey))


### PR DESCRIPTION
The RaygunClientMessage section of the Raygun crash report payload specifies some information about the assembly used to send payloads to Raygun, e.g. a unique name and version. This is sometimes used within Raygun to select stack trace formatters and an appropriate error grouping algorithm. This PR adds this section for the Raygun serilog sink.

The version is fetched via Reflection. If this is undesired, another option could be to hard code the version here, but that would need to be kept in sync with the actual assembly version every time it's changed.