### PR TITLE
Populate the environment section

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -129,7 +129,11 @@ namespace Serilog.Sinks.Raygun
             }
 
             // Build up the rest of the message
-            raygunMessage.Details.Environment = new RaygunEnvironmentMessage();
+#if NETSTANDARD2_0
+            raygunMessage.Details.Environment = RaygunEnvironmentMessageBuilder.Build(new RaygunSettings());
+#else
+            raygunMessage.Details.Environment = RaygunEnvironmentMessageBuilder.Build();
+#endif
             raygunMessage.Details.Tags = tags;
             raygunMessage.Details.UserCustomData = properties;
             raygunMessage.Details.MachineName = Environment.MachineName;


### PR DESCRIPTION
The "Environment" section in Raygun crash reports sent from this serilog sink was blank. This PR uses the available RaygunEnvironmentMessageBuilder to populate this section. This includes info such as CPU architecture, used/available memory, locale, timezone offset etc. Though what's currently available for .NET Standard is limited compared to .NET Framework.