### PR TITLE
Capture http request/response details

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random
 
 `default: ApplicationVersion`
 
+By default, crash reports sent to Raygun will have an ApplicationVersion field based on the version of the entry assembly for your application. If this is not being picked up correctly, or if you want to provide a different version, then you can do so by including the desired value in the logging properties collection.
+
+You can specify the property key that you place the version in by using this applicationVersionProperty setting. Otherwise the version will be read from the "ApplicationVersion" key.
+
 ```csharp
 Log.ForContext("CustomAppVersionProperty", "1.2.11").Error(new Exception("random error"), "other information");
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Crash reports sent to Raygun from this Serilog sink will include HTTP context de
 
 Setting ignoredFormFieldNames to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
-Note that HTTP headers, query parameters, cookies, server variables and raw request data can also be filtered out. Configuration to do so is described in the RaygunSettings section further below.
+Note that HTTP headers, query parameters, cookies, server variables and raw request data can also be filtered out. Configuration to do so is described in the [RaygunSettings](#raygun4net-features-configured-via-raygunsettings) section further below.
 
 #### groupKeyProperty
 `type: string`
@@ -159,9 +159,22 @@ This is false by default, which means that any exception that occur within Raygu
 
 ### IgnoreSensitiveFieldNames
 
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details where present. (Currently only supported in .NET Framework applications). IgnoreSensitiveFieldNames lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun.
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details where present. (Currently only supported in .NET Framework applications). IgnoreSensitiveFieldNames lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries to this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are listed below)
 
 Setting IgnoreSensitiveFieldNames to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
 Individual options are also available which function in the same way as IgnoreSensitiveFieldNames: IgnoreQueryParameterNames, IgnoreFormFieldNames, IgnoreHeaderNames, IgnoreCookieNames and IgnoreServerVariableNames.
 
+The IgnoreFormFieldNames entries will also strip out specified values from the raw request payload if it is multipart/form-data.
+
+### IsRawDataIgnored
+
+By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set IsRawDataIgnored to true.
+
+If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the IgnoreSensitiveFieldNames options described above. You'll also need to specify how the fields should be stripped from the raw request payload. Set UseXmlRawDataFilter to true for XML payloads or/and set UseKeyValuePairRawDataFilter to true for payloads of the format "key1=value1&key2=value2".
+
+Setting IsRawDataIgnoredWhenFilteringFailed to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
+
+### CrashReportingOfflineStorageEnabled
+
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the MaxCrashReportsStoredOffline option.

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Log.Logger = new LoggerConfiguration()
       "CustomUserInfoProperty")
     .CreateLogger();
 ```
-### Required
-#### applicationKey
+
+### applicationKey
 `type: string`
+
+`required`
 
 Each application you create in Raygun will have an API Key which you can pass in here to specify where the crash reports will be sent to. Although this is required, you can set this to null or empty string which would result in crash reports not being sent. This can be useful if you want to configure your local environment to not send crash reports to Raygun and then use config transforms or the like to provide an API key for other environments.
 
-### Optional
-#### wrapperExceptions
+### wrapperExceptions
 `type: IEnumerable<Type>`
 
 `default: null`
@@ -38,7 +39,7 @@ This is a list of wrapper exception types that you're not interested in logging 
 
 For example, you may not be interested in the details of an AggregateException, so you could include typeof(AggregateException) in this list of wrapperExceptions. All inner exceptions of any logged AggregateException will be sent to Raygun as separate crash reports.
 
-#### userNameProperty
+### userNameProperty
 `type: string`
 
 `default: UserName`
@@ -47,7 +48,7 @@ For example, you may not be interested in the details of an AggregateException, 
 Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random error"), "other information");
 ```
 
-#### applicationVersionProperty
+### applicationVersionProperty
 `type: string`
 
 `default: ApplicationVersion`
@@ -56,44 +57,48 @@ Log.ForContext("CustomUserNameProperty", "John Doe").Error(new Exception("random
 Log.ForContext("CustomAppVersionProperty", "1.2.11").Error(new Exception("random error"), "other information");
 ```
 
-#### restrictedToMinimumLevel
+### restrictedToMinimumLevel
 `type: LogEventLevel`
 
 `default: LogEventLevel.Error`
 
-#### formatProvider
+### formatProvider
 `type: IFormatProvider`
 
 `default: null`
 
-#### tags
+### tags
 `type: IEnumerable<string>`
 
 `default: null`
 
 This is a list of global tags that will be included on every crash report sent with this Serilog sink.
 
-#### ignoredFormFieldNames
+### ignoredFormFieldNames
 `type: IEnumerable<string>`
 
 `default: null`
 
 Crash reports sent to Raygun from this Serilog sink will include HTTP context details where present. (Currently only supported in .NET Framework applications). This option lets you specify a list of form fields that you do not want to be sent to Raygun.
 
-Setting ignoredFormFieldNames to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
+Setting `ignoredFormFieldNames` to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
 Note that HTTP headers, query parameters, cookies, server variables and raw request data can also be filtered out. Configuration to do so is described in the [RaygunSettings](#raygun4net-features-configured-via-raygunsettings) section further below.
 
-#### groupKeyProperty
+The `ignoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
+
+### groupKeyProperty
 `type: string`
 
 `default: GroupKey`
+
+Crash reports sent to Raygun will be grouped together based on stack trace and exception type information. The `groupKeyProperty` setting specifies a key in the logging properties collection where you can provide a grouping key. Crash reports containing a grouping key will not be grouped automatically by Raygun. Instead, crash reports with matching custom grouping keys will be grouped together.
 
 ```csharp
 Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Exception("random error"), "other information");
 ```
 
-#### tagsProperty
+### tagsProperty
 `type: string`
 
 `default: Tags`
@@ -105,7 +110,7 @@ Log.ForContext("CustomTagsProperty", new[] {"tag1", "tag2"}).Error(new Exception
 Log.Error(new Exception("random error"), "other information {@CustomTagsProperty}", new[] {"tag3", "tag4"});
 ```
 
-#### userInfoProperty
+### userInfoProperty
 `type: string`
 
 `default: null`
@@ -154,27 +159,39 @@ Then add a RaygunSettings element containing the desired settings somewhere with
 ```
 
 ### ThrowOnError
+`type: bool`
+
+`default: false`
 
 This is false by default, which means that any exception that occur within Raygun4Net itself will be silently caught. Setting this to true will allow any exceptions occurring in Raygun4Net to be thrown, which can help debug issues with Raygun4Net if crash reports aren't showing up in Raygun.
 
 ### IgnoreSensitiveFieldNames
+`type: string[]`
 
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details where present. (Currently only supported in .NET Framework applications). IgnoreSensitiveFieldNames lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries to this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are listed below)
+`default: null`
 
-Setting IgnoreSensitiveFieldNames to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). IgnoreSensitiveFieldNames lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries in this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are explained in the [IsRawDataIgnored](#israwdataignored) section below).
 
-Individual options are also available which function in the same way as IgnoreSensitiveFieldNames: IgnoreQueryParameterNames, IgnoreFormFieldNames, IgnoreHeaderNames, IgnoreCookieNames and IgnoreServerVariableNames.
+Setting `IgnoreSensitiveFieldNames` to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
-The IgnoreFormFieldNames entries will also strip out specified values from the raw request payload if it is multipart/form-data.
+Individual options are also available which function in the same way as IgnoreSensitiveFieldNames: `IgnoreQueryParameterNames`, `IgnoreFormFieldNames`, `IgnoreHeaderNames`, `IgnoreCookieNames` and `IgnoreServerVariableNames`.
+
+The `IgnoreFormFieldNames` entries will also strip out specified values from the raw request payload if it is multipart/form-data.
 
 ### IsRawDataIgnored
+`type: bool`
 
-By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set IsRawDataIgnored to true.
+`default: false`
 
-If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the IgnoreSensitiveFieldNames options described above. You'll also need to specify how the fields should be stripped from the raw request payload. Set UseXmlRawDataFilter to true for XML payloads or/and set UseKeyValuePairRawDataFilter to true for payloads of the format "key1=value1&key2=value2".
+By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. (Currently only supported in .NET Framework applications). If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set `IsRawDataIgnored` to true.
 
-Setting IsRawDataIgnoredWhenFilteringFailed to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
+If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the `IgnoreSensitiveFieldNames` options [described above](#ignoresensitivefieldnames). You'll also need to specify how the fields should be stripped from the raw request payload. Set `UseXmlRawDataFilter` to true for XML payloads or/and set `UseKeyValuePairRawDataFilter` to true for payloads of the format "key1=value1&key2=value2".
+
+Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
 
 ### CrashReportingOfflineStorageEnabled
+`type: bool`
 
-Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the MaxCrashReportsStoredOffline option.
+`default: true`
+
+Only available in .NET Framework applications. This is true by default which will cause crash reports to be saved to isolated storage (if possible) in cases where they fail to be sent to Raygun. This option lets you disable this functionality by setting it to false. When enabled, a maximum of 64 crash reports can be saved. This limit can be set lower than 64 via the `MaxCrashReportsStoredOffline` option.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each application you create in Raygun will have an API Key which you can pass in
 
 This is a list of wrapper exception types that you're not interested in logging to Raygun. Whenever an undesired wrapper exception is logged, it will be discarded and only the inner exception(s) will be logged.
 
-For example, you may not be interested in the details of an AggregateException, so you could include typeof(AggregateException) in this list of wrapperExceptions. All inner exceptions of any logged AggregateException will be sent to Raygun as separate crash reports.
+For example, you may not be interested in the details of an AggregateException, so you could include `typeof(AggregateException)` in this list of wrapperExceptions. All inner exceptions of any logged AggregateException would then be sent to Raygun as separate crash reports.
 
 ### userNameProperty
 `type: string`
@@ -79,7 +79,7 @@ This is a list of global tags that will be included on every crash report sent w
 
 `default: null`
 
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details where present. (Currently only supported in .NET Framework applications). This option lets you specify a list of form fields that you do not want to be sent to Raygun.
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). This option lets you specify a list of form fields that you do not want to be sent to Raygun.
 
 Setting `ignoredFormFieldNames` to a list that only contains "*" will cause no form fields to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
@@ -92,7 +92,7 @@ The `ignoreFormFieldNames` entries will also strip out specified values from the
 
 `default: GroupKey`
 
-Crash reports sent to Raygun will be grouped together based on stack trace and exception type information. The `groupKeyProperty` setting specifies a key in the logging properties collection where you can provide a grouping key. Crash reports containing a grouping key will not be grouped automatically by Raygun. Instead, crash reports with matching custom grouping keys will be grouped together.
+Crash reports sent to Raygun will be automatically grouped together based on stack trace and exception type information. The `groupKeyProperty` setting specifies a key in the logging properties collection where you can provide a grouping key. Crash reports containing a grouping key will not be grouped automatically by Raygun. Instead, crash reports with matching custom grouping keys will be grouped together.
 
 ```csharp
 Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Exception("random error"), "other information");
@@ -103,7 +103,7 @@ Log.ForContext("CustomGroupKeyProperty", "TransactionId-12345").Error(new Except
 
 `default: Tags`
 
-This allows you to specify a key in the properties collection that contains a list of tags to include on crash reports. Note that these will be included in addition to any global tags (describe above). If you set a list of tags in the properties collection multiple times (e.g. at different logging scopes) then only the latest list of tags will be used.
+This allows you to specify a key in the properties collection that contains a list of tags to include on crash reports. Note that these will be included in addition to any global tags [described above](#tags). If you set a list of tags in the properties collection multiple times (e.g. at different logging scopes) then only the latest list of tags will be used.
 
 ```csharp
 Log.ForContext("CustomTagsProperty", new[] {"tag1", "tag2"}).Error(new Exception("random error"), "other information");
@@ -170,7 +170,7 @@ This is false by default, which means that any exception that occur within Raygu
 
 `default: null`
 
-Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). IgnoreSensitiveFieldNames lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries in this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are explained in the [IsRawDataIgnored](#israwdataignored) section below).
+Crash reports sent to Raygun from this Serilog sink will include HTTP context details if present. (Currently only supported in .NET Framework applications). `IgnoreSensitiveFieldNames` lets you specify a list of HTTP query parameters, form fields, headers, cookies and server variables that you do not want to be sent to Raygun. Additionally, entries in this setting will be attempted to be stripped out of the raw request payload (more options for controlling this are explained in the `IsRawDataIgnored` section below).
 
 Setting `IgnoreSensitiveFieldNames` to a list that only contains "*" will cause none of these things to be sent to Raygun. Placing * before, after or at both ends of an entry will perform an ends-with, starts-with or contains operation respectively.
 
@@ -185,7 +185,7 @@ The `IgnoreFormFieldNames` entries will also strip out specified values from the
 
 By default, Raygun crash reports will capture the raw request payload of the current HTTP context if present. (Currently only supported in .NET Framework applications). If you would not like to include raw request payloads on crash reports sent to Raygun, then you can set `IsRawDataIgnored` to true.
 
-If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the `IgnoreSensitiveFieldNames` options [described above](#ignoresensitivefieldnames). You'll also need to specify how the fields should be stripped from the raw request payload. Set `UseXmlRawDataFilter` to true for XML payloads or/and set `UseKeyValuePairRawDataFilter` to true for payloads of the format "key1=value1&key2=value2".
+If you do want to include the raw request payload, but want to filter out sensitive fields, then you can use the `IgnoreSensitiveFieldNames` options described above. You'll also need to specify how the fields should be stripped from the raw request payload. Set `UseXmlRawDataFilter` to true for XML payloads or/and set `UseKeyValuePairRawDataFilter` to true for payloads of the format "key1=value1&key2=value2".
 
 Setting `IsRawDataIgnoredWhenFilteringFailed` to true will cause the entire raw request payload to be ignored in cases where specified sensitive values fail to be stripped out.
 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,35 @@ var userInfo = new RaygunIdentifierMessage("12345")
 
 Log.ForContext("CustomUserInfoProperty", userInfo, true).Error(new Exception("random error"), "other information");
 ```
+
+## Raygun4Net features
+
+This sink wraps the [Raygun4Net](https://github.com/MindscapeHQ/raygun4net) provider to build a crash report from an Exception and send it to Raygun. This makes the following Raygun4Net features available to you. To use these features, you need to add RaygunSettings to your configuration as explained below which is separate to the Serilog configuration.
+
+*.NET Core*
+
+Add a RaygunSettings block to your appsettings.config file where you can populate the settings that you want to use.
+
+```json
+"RaygunSettings": {
+  "Setting": "Value"
+}
+```
+
+*.NET Framework*
+
+Add the following section within the configSections element of your app.config or web.config file.
+
+```xml
+<section name="RaygunSettings" type="Mindscape.Raygun4Net.RaygunSettings, Mindscape.Raygun4Net"/>
+```
+
+Then add a RaygunSettings element containing the desired settings somewhere within the configuration element of the app.config or web.config file.
+
+```xml
+<RaygunSettings setting="value"/>
+```
+
+### ThrowOnError
+
+This is false by default, which means that any exception that occur within Raygun4Net itself will be silently caught. Setting this to true will allow any exceptions occurring in Raygun4Net to be thrown, which can help debug issues in Raygun4Net if crash reports aren't showing up in Raygun.

--- a/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/LoggerConfigurationRaygunExtensions.cs
@@ -58,9 +58,6 @@ namespace Serilog
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
-            if (string.IsNullOrWhiteSpace(applicationKey))
-                throw new ArgumentNullException("applicationKey");
-
             return loggerConfiguration.Sink(
                 new RaygunSink(formatProvider, applicationKey, wrapperExceptions, userNameProperty, applicationVersionProperty, tags, ignoredFormFieldNames, groupKeyProperty, tagsProperty, userInfoProperty),
                 restrictedToMinimumLevel);

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -71,9 +71,6 @@ namespace Serilog.Sinks.Raygun
             string tagsProperty = "Tags",
             string userInfoProperty = null)
         {
-            if (string.IsNullOrEmpty(applicationKey))
-                throw new ArgumentNullException("applicationKey");
-
             _formatProvider = formatProvider;
             _userNameProperty = userNameProperty;
             _applicationVersionProperty = applicationVersionProperty;
@@ -82,7 +79,12 @@ namespace Serilog.Sinks.Raygun
             _tagsProperty = tagsProperty;
             _userInfoProperty = userInfoProperty;
 
+#if NETSTANDARD2_0
             _client = new RaygunClient(applicationKey);
+#else
+            _client = string.IsNullOrWhiteSpace(applicationKey) ? new RaygunClient() : new RaygunClient(applicationKey);
+#endif
+
             if (wrapperExceptions != null)
                 _client.AddWrapperExceptions(wrapperExceptions.ToArray());
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -85,6 +85,9 @@ namespace Serilog.Sinks.Raygun
             _client = string.IsNullOrWhiteSpace(applicationKey) ? new RaygunClient() : new RaygunClient(applicationKey);
 #endif
 
+            // Raygun4Net adds these two wrapper exceptions by default, but as there is no way to remove them through this Serilog sink, we replace them entirely with the configured wrapper exceptions.
+            _client.RemoveWrapperExceptions(typeof(TargetInvocationException), Type.GetType("System.Web.HttpUnhandledException, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"));
+
             if (wrapperExceptions != null)
                 _client.AddWrapperExceptions(wrapperExceptions.ToArray());
 

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -42,7 +42,6 @@ namespace Serilog.Sinks.Raygun
         private readonly string _userNameProperty;
         private readonly string _applicationVersionProperty;
         private readonly IEnumerable<string> _tags;
-        private readonly IEnumerable<string> _ignoredFormFieldNames;
         private readonly string _groupKeyProperty;
         private readonly string _tagsProperty;
         private readonly string _userInfoProperty;
@@ -79,7 +78,6 @@ namespace Serilog.Sinks.Raygun
             _userNameProperty = userNameProperty;
             _applicationVersionProperty = applicationVersionProperty;
             _tags = tags ?? new string[0];
-            _ignoredFormFieldNames = ignoredFormFieldNames ?? Enumerable.Empty<string>();
             _groupKeyProperty = groupKeyProperty;
             _tagsProperty = tagsProperty;
             _userInfoProperty = userInfoProperty;
@@ -87,6 +85,9 @@ namespace Serilog.Sinks.Raygun
             _client = new RaygunClient(applicationKey);
             if (wrapperExceptions != null)
                 _client.AddWrapperExceptions(wrapperExceptions.ToArray());
+
+            if(ignoredFormFieldNames != null)
+               _client.IgnoreFormFieldNames(ignoredFormFieldNames.ToArray());
 
             _client.SendingMessage += OnSendingMessage;
         }


### PR DESCRIPTION
As the branch name suggests, the focus for this PR was to capture HTTP request and response details and include them in the Raygun payloads where relevant. I did this because I noticed one of the options is "ignoredFormFieldNames" which is related to the HTTP request section of the Raygun payload, and yet this sink no longer captures these details.

The way I have added this support is by replacing the Send(message) call with a Send(exception) call. In order to maintain all the functionality that this Sink currently has, we attach an event handler to the SendingMessage event on the Raygun client. This event is fired whenever a message is about to be sent to Raygun, and provides the message payload model for reading and mutating. In the event handler, most of the logic will read the UserCustomData (which is set to be the log properties) and then use those values to add/update various other parts of the message model.

This worked out very smoothly, apart from the timestamp which I maintained by introducing a new property key. This gets set before sending the exception, then gets read and removed from the properties list in the SendingMessage event handler.

The result of this has regained support for capturing HTTP request/response details, but also unlocks other features provided by Raygun4Net:
* Stripping out wrapped exceptions - there is a configuration option for this already called "wrapperExceptions", but this feature was being bypassed due to sending a manually built message payload model. This strips away any unwanted outer exception and only sends the resulting inner exception(s). Unlike with Raygun4Net, this sink will not strip any default wrapper exception - so any undesired wrapper exceptions needs to be specified through this option.
* Application version will automatically be picked up from the version of the entry assembly of the application.
* Avoid accidentally sending the same exception instance multiple times. It's possible to setup logging in such a way that the same exception instance tries to be logged to Raygun multiple times - for example, you could have both Serilog and Raygun integrated, or hook into multiple ways to capture unhandled exceptions. Sending the same Exception instances to Raygun multiple times will use up Raygun customers monthly usage - so Raygun4Net automatically prevents this.
* Offline exception report storage (for apps that can use isolated storage). When a crash report fails to be sent to Raygun e.g. internet connectivity issues, then they get stored to local storage to be sent another time.
* Most of the [RaygunSettings](https://github.com/MindscapeHQ/raygun4net/blob/master/Mindscape.Raygun4Net/RaygunSettings.cs) can now be used, a lot of which relate to capturing HTTP details.

Additionally, this PR resolves https://github.com/serilog/serilog-sinks-raygun/issues/31 by removing the null/whitespace check on the api key.