### PR TITLE
Fix stacktrace when no exception is provided

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/NullException.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/NullException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Serilog.Sinks.Raygun.Sinks.Raygun
+{
+    // This is used to carry the code execution StackTrace from the Serilog Sink to the Raygun callback in the case that no exception has been provided.
+    internal class NullException : Exception
+    {
+        private readonly StackTrace _stackTrace;
+
+        public NullException(StackTrace stacktrace)
+        {
+            _stackTrace = stacktrace;
+        }
+
+        public StackTrace StackTrace
+        {
+            get { return _stackTrace; }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/serilog/serilog-sinks-raygun/issues/36

When an error is logged without an Exception instance, the current execution trace up to the point the error was logged is intended to be sent to Raygun in place of the Exception stack trace. This has not been working because the stack trace is being created in a callback method that's called from a background thread.

This PR fixes this bug by creating the code execution stack trace within the Emit method. The SendingMessage callback has been replaced with the CustomGroupingKey callback. This allows us to create a new NullException instance to transfer the prepared stack trace from the Emit method to the callback via the event arguments.