### PR TITLE
Changed property name to avoid build warning

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/NullException.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/NullException.cs
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.Raygun.Sinks.Raygun
             _stackTrace = stacktrace;
         }
 
-        public StackTrace StackTrace
+        public StackTrace CodeExecutionStackTrace
         {
             get { return _stackTrace; }
         }

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -155,7 +155,7 @@ namespace Serilog.Sinks.Raygun
                         {
                             ClassName = properties[LogMessageTemplateProperty].ToString("l", null),
                             Message = properties[RenderedLogMessageProperty].ToString("l", null),
-                            StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.StackTrace)
+                            StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
                         };
                     }
 


### PR DESCRIPTION
Fixes the following build warnings caused by previous branch that introduced the NullException type:

Sinks\Raygun\NullException.cs(16,27): warning CS0114: 'NullException.StackTrace' hides inherited member 'Exception.StackTrace'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.