### PR TITLE
Fix for FormatException when user property is a Guid

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null

--- a/serilog-sinks-raygun.sln
+++ b/serilog-sinks-raygun.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun", "src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj", "{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun.Tests", "test\Serilog.Sinks.Raygun.Tests\Serilog.Sinks.Raygun.Tests.csproj", "{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7D3E0A9-08FE-4B4F-B7D6-56FF8053B532}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
@@ -9,7 +9,8 @@ namespace Serilog.Sinks.Raygun
         public static string AsString(this LogEventPropertyValue propertyValue)
         {
             if (!(propertyValue is ScalarValue scalar)) return null;
-            return scalar.Value is string s ? s : scalar.Value.ToString();
+            // Handle string values differently as the ToString() method will wrap the string in unwanted quotes
+            return scalar.Value is string s ? s : scalar.ToString();
         }
         
         public static string AsString(this LogEventProperty property)
@@ -21,7 +22,7 @@ namespace Serilog.Sinks.Raygun
         {
             var scalar = property.Value as ScalarValue;
             if (scalar?.Value == null) return defaultIfNull;
-            return int.TryParse(property.Value.ToString(), out int result) ? result : defaultIfNull;
+            return int.TryParse(property.Value.AsString(), out int result) ? result : defaultIfNull;
         }
 
         public static IDictionary AsDictionary(this LogEventProperty property)
@@ -29,7 +30,7 @@ namespace Serilog.Sinks.Raygun
             if (!(property.Value is DictionaryValue value)) return null;
 
             return value.Elements.ToDictionary(
-                kv => kv.Key.ToString("l", null),
+                kv => kv.Key.AsString(),
                 kv => kv.Value is ScalarValue scalarValue ? scalarValue.Value : kv.Value);
         }
     }

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/LogEventPropertyExtensions.cs
@@ -6,16 +6,22 @@ namespace Serilog.Sinks.Raygun
 {
     public static class LogEventPropertyExtensions
     {
+        public static string AsString(this LogEventPropertyValue propertyValue)
+        {
+            if (!(propertyValue is ScalarValue scalar)) return null;
+            return scalar.Value is string s ? s : scalar.Value.ToString();
+        }
+        
         public static string AsString(this LogEventProperty property)
         {
-            var scalar = property.Value as ScalarValue;
-            return scalar?.Value != null ? property.Value.ToString("l", null) : null;
+            return property.Value.AsString();
         }
 
         public static int AsInteger(this LogEventProperty property, int defaultIfNull = 0)
         {
             var scalar = property.Value as ScalarValue;
-            return scalar?.Value != null ? int.TryParse(property.Value.ToString(), out int result) ? result : defaultIfNull : defaultIfNull;
+            if (scalar?.Value == null) return defaultIfNull;
+            return int.TryParse(property.Value.ToString(), out int result) ? result : defaultIfNull;
         }
 
         public static IDictionary AsDictionary(this LogEventProperty property)

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -194,7 +194,7 @@ namespace Serilog.Sinks.Raygun
                         properties.ContainsKey(_userNameProperty) &&
                         properties[_userNameProperty] != null)
                     {
-	                      details.User = new RaygunIdentifierMessage(properties[_userNameProperty].AsString());
+                        details.User = new RaygunIdentifierMessage(properties[_userNameProperty].AsString());
 
                         properties.Remove(_userNameProperty);
                     }

--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -152,8 +152,8 @@ namespace Serilog.Sinks.Raygun
                     {
                         details.Error = new RaygunErrorMessage
                         {
-                            ClassName = properties[LogMessageTemplateProperty].ToString("l", null),
-                            Message = properties[RenderedLogMessageProperty].ToString("l", null),
+                            ClassName = properties[LogMessageTemplateProperty].AsString(),
+                            Message = properties[RenderedLogMessageProperty].AsString(),
                             StackTrace = RaygunErrorMessageBuilder.BuildStackTrace(nullException.CodeExecutionStackTrace)
                         };
                     }
@@ -194,7 +194,7 @@ namespace Serilog.Sinks.Raygun
                         properties.ContainsKey(_userNameProperty) &&
                         properties[_userNameProperty] != null)
                     {
-                        details.User = new RaygunIdentifierMessage(properties[_userNameProperty].ToString("l", null));
+	                      details.User = new RaygunIdentifierMessage(properties[_userNameProperty].AsString());
 
                         properties.Remove(_userNameProperty);
                     }
@@ -204,7 +204,7 @@ namespace Serilog.Sinks.Raygun
                         properties.ContainsKey(_applicationVersionProperty) &&
                         properties[_applicationVersionProperty] != null)
                     {
-                        details.Version = properties[_applicationVersionProperty].ToString("l", null);
+                        details.Version = properties[_applicationVersionProperty].AsString();
 
                         properties.Remove(_applicationVersionProperty);
                     }
@@ -212,7 +212,7 @@ namespace Serilog.Sinks.Raygun
                     // Add the custom group key if provided
                     if (properties.TryGetValue(_groupKeyProperty, out var customKey))
                     {
-                        details.GroupingKey = customKey.ToString("l", null);
+                        details.GroupingKey = customKey.AsString();
 
                         properties.Remove(_groupKeyProperty);
                     }

--- a/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
+++ b/test/Serilog.Sinks.Raygun.Tests/Serilog.Sinks.Raygun.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+		<PackageReference Include="NUnit" Version="3.13.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageReference Include="coverlet.collector" Version="3.0.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/LogEventPropertyExtensionsTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/LogEventPropertyExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
+{
+	[TestFixture]
+	public class LogEventPropertyExtensionsTests
+	{
+		static object[] AsString_WithScalarValue_Cases =
+		{
+			new object[] { "test-value", "test-value" },
+			new object[] { Guid.Parse("{1DF0D385-220D-49F0-A53E-717E3E313E7C}"), "1df0d385-220d-49f0-a53e-717e3e313e7c" },
+			new object[] { 1337, "1337" },
+			new object[] { 1337.7331, "1337.7331" },
+			new object[] { null, "null" }
+		};
+
+		static object[] AsInteger_WithScalarValue_Cases =
+		{
+			new object[] { "-1", -1 },
+			new object[] { "1337", 1337 },
+			new object[] { "invalid", 0 },
+			new object[] { null, 0 }
+		};
+
+		[TestCaseSource(nameof(AsString_WithScalarValue_Cases))]
+		public void AsString_WithScalarValue_ReturnsExpectedString(object scalarValue, string expectedValue)
+		{
+			var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
+			string outputValue = logEventProperty.AsString();
+
+			Assert.That(outputValue, Is.EqualTo(expectedValue));
+		}
+
+		[Test]
+		public void AsString_WithSequenceValue_ReturnsNull()
+		{
+			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+			string outputValue = logEventProperty.AsString();
+
+			Assert.That(outputValue, Is.EqualTo(null));
+		}
+
+		[TestCaseSource(nameof(AsInteger_WithScalarValue_Cases))]
+		public void AsInteger_WithScalarValue_ReturnsExpectedInteger(object scalarValue, int expectedValue)
+		{
+			var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
+			int outputValue = logEventProperty.AsInteger();
+
+			Assert.That(outputValue, Is.EqualTo(expectedValue));
+		}
+
+		[Test]
+		public void AsInteger_WithSequenceValue_ReturnsDefaultValue()
+		{
+			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+			int outputValue = logEventProperty.AsInteger(99);
+
+			Assert.That(outputValue, Is.EqualTo(99));
+		}
+
+		[Test]
+		public void AsDictionary_WithDictionaryValue_ReturnsDictionaryWithCorrectValues()
+		{
+			var logEventProperty = new LogEventProperty("test", new DictionaryValue(new[]
+			{
+				new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item1"), new ScalarValue("item1_value")),
+				new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item2"), new ScalarValue("item2_value"))
+			}));
+
+			IDictionary outputValue = logEventProperty.AsDictionary();
+
+			Assert.That(outputValue, Contains.Key("item1").WithValue("item1_value"));
+			Assert.That(outputValue, Contains.Key("item2").WithValue("item2_value"));
+		}
+
+		[Test]
+		public void AsDictionary_WithSequenceValue_ReturnsNull()
+		{
+			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+			IDictionary outputValue = logEventProperty.AsDictionary();
+
+			Assert.That(outputValue, Is.EqualTo(null));
+		}
+	}
+}

--- a/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/LogEventPropertyExtensionsTests.cs
+++ b/test/Serilog.Sinks.Raygun.Tests/Sinks/Raygun/LogEventPropertyExtensionsTests.cs
@@ -6,84 +6,84 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Raygun.Tests.Sinks.Raygun
 {
-	[TestFixture]
-	public class LogEventPropertyExtensionsTests
-	{
-		static object[] AsString_WithScalarValue_Cases =
-		{
-			new object[] { "test-value", "test-value" },
-			new object[] { Guid.Parse("{1DF0D385-220D-49F0-A53E-717E3E313E7C}"), "1df0d385-220d-49f0-a53e-717e3e313e7c" },
-			new object[] { 1337, "1337" },
-			new object[] { 1337.7331, "1337.7331" },
-			new object[] { null, "null" }
-		};
+    [TestFixture]
+    public class LogEventPropertyExtensionsTests
+    {
+        static object[] AsString_WithScalarValue_Cases =
+        {
+            new object[] { "test-value", "test-value" },
+            new object[] { Guid.Parse("{1DF0D385-220D-49F0-A53E-717E3E313E7C}"), "1df0d385-220d-49f0-a53e-717e3e313e7c" },
+            new object[] { 1337, "1337" },
+            new object[] { 1337.7331, "1337.7331" },
+            new object[] { null, "null" }
+        };
 
-		static object[] AsInteger_WithScalarValue_Cases =
-		{
-			new object[] { "-1", -1 },
-			new object[] { "1337", 1337 },
-			new object[] { "invalid", 0 },
-			new object[] { null, 0 }
-		};
+        static object[] AsInteger_WithScalarValue_Cases =
+        {
+            new object[] { "-1", -1 },
+            new object[] { "1337", 1337 },
+            new object[] { "invalid", 0 },
+            new object[] { null, 0 }
+        };
 
-		[TestCaseSource(nameof(AsString_WithScalarValue_Cases))]
-		public void AsString_WithScalarValue_ReturnsExpectedString(object scalarValue, string expectedValue)
-		{
-			var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
-			string outputValue = logEventProperty.AsString();
+        [TestCaseSource(nameof(AsString_WithScalarValue_Cases))]
+        public void AsString_WithScalarValue_ReturnsExpectedString(object scalarValue, string expectedValue)
+        {
+            var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
+            string outputValue = logEventProperty.AsString();
 
-			Assert.That(outputValue, Is.EqualTo(expectedValue));
-		}
+            Assert.That(outputValue, Is.EqualTo(expectedValue));
+        }
 
-		[Test]
-		public void AsString_WithSequenceValue_ReturnsNull()
-		{
-			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
-			string outputValue = logEventProperty.AsString();
+        [Test]
+        public void AsString_WithSequenceValue_ReturnsNull()
+        {
+            var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+            string outputValue = logEventProperty.AsString();
 
-			Assert.That(outputValue, Is.EqualTo(null));
-		}
+            Assert.That(outputValue, Is.EqualTo(null));
+        }
 
-		[TestCaseSource(nameof(AsInteger_WithScalarValue_Cases))]
-		public void AsInteger_WithScalarValue_ReturnsExpectedInteger(object scalarValue, int expectedValue)
-		{
-			var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
-			int outputValue = logEventProperty.AsInteger();
+        [TestCaseSource(nameof(AsInteger_WithScalarValue_Cases))]
+        public void AsInteger_WithScalarValue_ReturnsExpectedInteger(object scalarValue, int expectedValue)
+        {
+            var logEventProperty = new LogEventProperty("test", new ScalarValue(scalarValue));
+            int outputValue = logEventProperty.AsInteger();
 
-			Assert.That(outputValue, Is.EqualTo(expectedValue));
-		}
+            Assert.That(outputValue, Is.EqualTo(expectedValue));
+        }
 
-		[Test]
-		public void AsInteger_WithSequenceValue_ReturnsDefaultValue()
-		{
-			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
-			int outputValue = logEventProperty.AsInteger(99);
+        [Test]
+        public void AsInteger_WithSequenceValue_ReturnsDefaultValue()
+        {
+            var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+            int outputValue = logEventProperty.AsInteger(99);
 
-			Assert.That(outputValue, Is.EqualTo(99));
-		}
+            Assert.That(outputValue, Is.EqualTo(99));
+        }
 
-		[Test]
-		public void AsDictionary_WithDictionaryValue_ReturnsDictionaryWithCorrectValues()
-		{
-			var logEventProperty = new LogEventProperty("test", new DictionaryValue(new[]
-			{
-				new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item1"), new ScalarValue("item1_value")),
-				new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item2"), new ScalarValue("item2_value"))
-			}));
+        [Test]
+        public void AsDictionary_WithDictionaryValue_ReturnsDictionaryWithCorrectValues()
+        {
+            var logEventProperty = new LogEventProperty("test", new DictionaryValue(new[]
+            {
+                new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item1"), new ScalarValue("item1_value")),
+                new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue("item2"), new ScalarValue("item2_value"))
+            }));
 
-			IDictionary outputValue = logEventProperty.AsDictionary();
+            IDictionary outputValue = logEventProperty.AsDictionary();
 
-			Assert.That(outputValue, Contains.Key("item1").WithValue("item1_value"));
-			Assert.That(outputValue, Contains.Key("item2").WithValue("item2_value"));
-		}
+            Assert.That(outputValue, Contains.Key("item1").WithValue("item1_value"));
+            Assert.That(outputValue, Contains.Key("item2").WithValue("item2_value"));
+        }
 
-		[Test]
-		public void AsDictionary_WithSequenceValue_ReturnsNull()
-		{
-			var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
-			IDictionary outputValue = logEventProperty.AsDictionary();
+        [Test]
+        public void AsDictionary_WithSequenceValue_ReturnsNull()
+        {
+            var logEventProperty = new LogEventProperty("test", new SequenceValue(Array.Empty<LogEventPropertyValue>()));
+            IDictionary outputValue = logEventProperty.AsDictionary();
 
-			Assert.That(outputValue, Is.EqualTo(null));
-		}
-	}
+            Assert.That(outputValue, Is.EqualTo(null));
+        }
+    }
 }


### PR DESCRIPTION
This PR changes how string values are extracted to not rely on the `.ToString("l")` method. This method was used to prevent an extra quotes being applied to string values as they're extracted into the Raygun error payload, see https://github.com/serilog/serilog/blob/dev/src/Serilog/Events/ScalarValue.cs#L67

However, when a `ScalarValue` was not a string and was a value that implements `IFormattable`, then the "l" format is provided to the formatter, which would end up being an invalid format specification, specifically when the value is a Guid.

This PR introduces some extension methods so when a value is extracted as a string, and it is already a string type, then it takes the original string value, otherwise is uses the `ToString()` method of the value without any format specifier. This ensures no extra quotes are applied to string values, and also works when the value implements `IFormattable`, like Guids.

Example error that would occur when `userNameProperty` is set to a property that is a Guid. It would occur as "l" is passed to the `Guid.ToString()` method which causes an exception.
![image](https://user-images.githubusercontent.com/17053307/155645203-ec9b63d5-5dd6-404c-a424-c751e0e8a8a3.png)

After this fix is applied, the following example is where the Raygun error payload contains a user identifier that is a Guid:
![image](https://user-images.githubusercontent.com/17053307/155645564-d9a60dd4-658a-409c-8691-b14557091feb.png)